### PR TITLE
Polyencoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ We provide pretrained cross-lingual language models, all trained with the MLM ob
 | English-Romanian | [Model](https://dl.fbaipublicfiles.com/XLM/mlm_enro_1024.pth)       | [BPE codes](https://dl.fbaipublicfiles.com/XLM/codes_enro)    | [Vocabulary](https://dl.fbaipublicfiles.com/XLM/vocab_enro)    |
 | XNLI-15          | [Model](https://dl.fbaipublicfiles.com/XLM/mlm_tlm_xnli15_1024.pth) | [BPE codes](https://dl.fbaipublicfiles.com/XLM/codes_xnli_15) | [Vocabulary](https://dl.fbaipublicfiles.com/XLM/vocab_xnli_15) |
 
-The English-French, English-German and English-Romanian models are the ones we used in the paper for MT pretraining. If you use these models, you should use the same data preprocessing / BPE codes to preprocess your data. See the preprocessing commands in [get-data-nmt.sh](https://github.com/facebookresearch/XLM/blob/master/get-data-nmt.sh).
+The English-French, English-German and English-Romanian models are the ones we used in the paper for MT pretraining. They are trained with monolingual data only, with the MLM objective. If you use these models, you should use the same data preprocessing / BPE codes to preprocess your data. See the preprocessing commands in [get-data-nmt.sh](https://github.com/facebookresearch/XLM/blob/master/get-data-nmt.sh).
 
-XNLI-15 is the model used in the paper for XNLI fine-tuning. It handles English, French, Spanish, German, Greek, Bulgarian, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, Hindi, Swahili and Urdu. For this model we used a different preprocessing than for the MT models (such as lowercasing and accents removal).
+XNLI-15 is the model used in the paper for XNLI fine-tuning. It handles English, French, Spanish, German, Greek, Bulgarian, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, Hindi, Swahili and Urdu. It is trained with the MLM and the TLM objectives. For this model we used a different preprocessing than for the MT models (such as lowercasing and accents removal).
 
 ## Generating cross-lingual sentence representations
 
@@ -146,7 +146,7 @@ python train.py
 --stopping_criterion _valid_mlm_ppl,10  # end experiment if stopping criterion does not improve
 ```
 
-If parallel data is available, the TLM objective can be used with `--mlm_steps 'en-fr'`. To train with both the MLM and TLM objective, you can use `--mlm_steps 'en,fr,en-fr'`. We provide models trained with the command above for English-French, English-German and English-Romanian, along with the BPE codes and vocabulary used to preprocess the data.
+If parallel data is available, the TLM objective can be used with `--mlm_steps 'en-fr'`. To train with both the MLM and TLM objective, you can use `--mlm_steps 'en,fr,en-fr'`. We provide models trained with the MLM objective for English-French, English-German and English-Romanian, along with the BPE codes and vocabulary used to preprocess the data.
 
 ### Train on unsupervised MT from a pretrained model
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We provide pretrained cross-lingual language models, all trained with the MLM ob
 | English-Romanian | [Model](https://dl.fbaipublicfiles.com/XLM/mlm_enro_1024.pth)       | [BPE codes](https://dl.fbaipublicfiles.com/XLM/codes_enro)    | [Vocabulary](https://dl.fbaipublicfiles.com/XLM/vocab_enro)    |
 | XNLI-15          | [Model](https://dl.fbaipublicfiles.com/XLM/mlm_tlm_xnli15_1024.pth) | [BPE codes](https://dl.fbaipublicfiles.com/XLM/codes_xnli_15) | [Vocabulary](https://dl.fbaipublicfiles.com/XLM/vocab_xnli_15) |
 
-The English-French, English-German and English-Romanian models are the ones we used in the paper for MT pretraining. If you use these models, you should use the same data preprocessing / BPE codes to preprocess your data. See the preprocessing commands in [get-data-nmt.sh](https://github.com/fairinternal/XLM/blob/master/get-data-nmt.sh).
+The English-French, English-German and English-Romanian models are the ones we used in the paper for MT pretraining. If you use these models, you should use the same data preprocessing / BPE codes to preprocess your data. See the preprocessing commands in [get-data-nmt.sh](https://github.com/facebookresearch/XLM/blob/master/get-data-nmt.sh).
 
 XNLI-15 is the model used in the paper for XNLI fine-tuning. It handles English, French, Spanish, German, Greek, Bulgarian, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, Hindi, Swahili and Urdu. For this model we used a different preprocessing than for the MT models (such as lowercasing and accents removal).
 

--- a/get-data-glue.sh
+++ b/get-data-glue.sh
@@ -1,0 +1,188 @@
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+set -e
+
+# data paths
+MAIN_PATH=$PWD
+OUTPATH=$PWD/data/glue_test
+PROCESSED_PATH=$PWD/data/processed/XLM15
+CODES_PATH=$MAIN_PATH/codes_xnli_15
+VOCAB_PATH=$MAIN_PATH/vocab_xnli_15
+URLPATH=https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2F
+
+# tools paths
+TOOLS_PATH=$PWD/tools
+TOKENIZE=$TOOLS_PATH/tokenize.sh
+MOSES=$TOOLS_PATH/mosesdecoder
+REPLACE_UNICODE_PUNCT=$MOSES/scripts/tokenizer/replace-unicode-punctuation.perl
+NORM_PUNC=$MOSES/scripts/tokenizer/normalize-punctuation.perl
+REM_NON_PRINT_CHAR=$MOSES/scripts/tokenizer/remove-non-printing-char.perl
+LOWER_REMOVE_ACCENT=$TOOLS_PATH/lowercase_and_remove_accent.py
+FASTBPE=$TOOLS_PATH/fastBPE/fast
+
+# install tools
+./install-tools.sh
+
+# create directories
+# rm -r $OUTPATH
+mkdir -p $OUTPATH
+
+
+# SST-2
+if [ ! -d $OUTPATH/SST-2 ]; then
+    if [ ! -f $OUTPATH/SST-2zip ]; then
+        wget -c "${URLPATH}SST-2.zip?alt=media&token=aabc5f6b-e466-44a2-b9b4-cf6337f84ac8" -P $OUTPATH
+    fi
+    unzip $OUTPATH/*SST-2* -d $OUTPATH
+    for split in train dev
+    do
+      sed '1d' $OUTPATH/SST-2/${split}.tsv | cut -f1 | $REPLACE_UNICODE_PUNCT | $NORM_PUNC -l en | $REM_NON_PRINT_CHAR > $OUTPATH/SST-2/${split}.x
+      sed '1d' $OUTPATH/SST-2/${split}.tsv | cut -f2 > $OUTPATH/SST-2/${split}.y
+      paste $OUTPATH/SST-2/${split}.x $OUTPATH/SST-2/${split}.y > $OUTPATH/SST-2/${split}.xlm.tsv
+      rm $OUTPATH/SST-2/${split}.x $OUTPATH/SST-2/${split}.y
+    done
+    sed '1d' $OUTPATH/SST-2/test.tsv | cut -f2 | $REPLACE_UNICODE_PUNCT | $NORM_PUNC -l en | $REM_NON_PRINT_CHAR > $OUTPATH/SST-2/test.xlm.tsv
+    rm $OUTPATH/*SST-2.zip* 
+
+fi
+
+# SST-B
+if [ ! -d $OUTPATH/STS-B ]; then
+    if [ ! -f $OUTPATH/STS-B.zip ]; then
+        wget -c "${URLPATH}STS-B.zip?alt=media&token=bddb94a7-8706-4e0d-a694-1109e12273b5" -P $OUTPATH
+    fi
+    unzip $OUTPATH/*STS-B* -d $OUTPATH
+    for split in train dev test
+    do
+      sed '1d' $OUTPATH/STS-B/${split}.tsv | cut -f8 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/STS-B/${split}.x1
+      sed '1d' $OUTPATH/STS-B/${split}.tsv | cut -f9 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/STS-B/${split}.x2
+      if [ "$split" != "test" ]; then
+        sed '1d' $OUTPATH/STS-B/${split}.tsv | cut -f10 > $OUTPATH/STS-B/${split}.y
+        paste $OUTPATH/STS-B/${split}.x1 $OUTPATH/STS-B/${split}.x2 $OUTPATH/STS-B/${split}.y > $OUTPATH/STS-B/${split}.xlm.tsv
+        rm $OUTPATH/STS-B/${split}.x1 $OUTPATH/STS-B/${split}.x2 $OUTPATH/STS-B/${split}.y
+      else
+        paste $OUTPATH/STS-B/${split}.x1 $OUTPATH/STS-B/${split}.x2 > $OUTPATH/STS-B/${split}.xlm.tsv
+        rm $OUTPATH/STS-B/${split}.x1 $OUTPATH/STS-B/${split}.x2
+      fi
+    done
+    rm $OUTPATH/*STS-B.zip* 
+
+fi
+
+# MNLI
+if [ ! -d $OUTPATH/MNLI ]; then
+    if [ ! -f $OUTPATH/MNLI.zip ]; then
+        wget -c "${URLPATH}MNLI.zip?alt=media&token=50329ea1-e339-40e2-809c-10c40afff3ce" -P $OUTPATH
+    fi
+    unzip $OUTPATH/*MNLI* -d $OUTPATH
+    mv $OUTPATH/MNLI/dev_matched.tsv $OUTPATH/MNLI/dev.tsv
+    mv $OUTPATH/MNLI/test_matched.tsv $OUTPATH/MNLI/test.tsv
+    for split in train dev test
+    do
+      sed '1d' $OUTPATH/MNLI/${split}.tsv | cut -f9 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/MNLI/${split}.x1
+      sed '1d' $OUTPATH/MNLI/${split}.tsv | cut -f10 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/MNLI/${split}.x2
+      sed '1d' $OUTPATH/MNLI/${split}.tsv | cut -f12 > $OUTPATH/MNLI/${split}.y
+      paste $OUTPATH/MNLI/${split}.x1 $OUTPATH/MNLI/${split}.x2 $OUTPATH/MNLI/${split}.y > $OUTPATH/MNLI/${split}.xlm.tsv
+      rm $OUTPATH/MNLI/${split}.x1 $OUTPATH/MNLI/${split}.x2 $OUTPATH/MNLI/${split}.y
+    done
+    rm $OUTPATH/*MNLI.zip*
+
+fi
+
+# QNLI
+if [ ! -d $OUTPATH/QNLI ]; then
+    if [ ! -f $OUTPATH/QNLIv2.zip ]; then
+        wget -c "${URLPATH}QNLIv2.zip?alt=media&token=6fdcf570-0fc5-4631-8456-9505272d1601" -P $OUTPATH
+    fi
+    unzip $OUTPATH/*QNLIv2* -d $OUTPATH
+    for split in train dev test
+    do
+      sed '1d' $OUTPATH/QNLI/${split}.tsv | cut -f2 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/QNLI/${split}.x1
+      sed '1d' $OUTPATH/QNLI/${split}.tsv | cut -f3 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/QNLI/${split}.x2
+      if [ "$split" != "test" ]; then
+        sed '1d' $OUTPATH/QNLI/${split}.tsv | cut -f4 > $OUTPATH/QNLI/${split}.y
+        paste $OUTPATH/QNLI/${split}.x1 $OUTPATH/QNLI/${split}.x2 $OUTPATH/QNLI/${split}.y > $OUTPATH/QNLI/${split}.xlm.tsv
+        rm $OUTPATH/QNLI/${split}.x1 $OUTPATH/QNLI/${split}.x2 $OUTPATH/QNLI/${split}.y
+      else
+        paste $OUTPATH/QNLI/${split}.x1 $OUTPATH/QNLI/${split}.x2 > $OUTPATH/QNLI/${split}.xlm.tsv
+        rm $OUTPATH/QNLI/${split}.x1 $OUTPATH/QNLI/${split}.x2
+      fi
+    done
+    rm $OUTPATH/*QNLIv2.zip* 
+
+fi
+
+# QQP
+if [ ! -d $OUTPATH/QQP ]; then
+    if [ ! -f $OUTPATH/QQP.zip ]; then
+        wget -c "${URLPATH}QQP.zip?alt=media&token=700c6acf-160d-4d89-81d1-de4191d02cb5" -P $OUTPATH
+    fi
+    unzip $OUTPATH/*QQP* -d $OUTPATH
+    for split in train dev test
+    do
+      if [ "$split" != "test" ]; then
+        sed '1d' $OUTPATH/QQP/${split}.tsv | cut -f4 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/QQP/${split}.x1
+        sed '1d' $OUTPATH/QQP/${split}.tsv | cut -f5 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/QQP/${split}.x2
+        sed '1d' $OUTPATH/QQP/${split}.tsv | cut -f6 > $OUTPATH/QQP/${split}.y
+        paste $OUTPATH/QQP/${split}.x1 $OUTPATH/QQP/${split}.x2 $OUTPATH/QQP/${split}.y > $OUTPATH/QQP/${split}.xlm.tsv
+        rm $OUTPATH/QQP/${split}.x1 $OUTPATH/QQP/${split}.x2 $OUTPATH/QQP/${split}.y
+      else
+        sed '1d' $OUTPATH/QQP/${split}.tsv | cut -f2 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/QQP/${split}.x1
+        sed '1d' $OUTPATH/QQP/${split}.tsv | cut -f3 | $TOKENIZE en | python $LOWER_REMOVE_ACCENT > $OUTPATH/QQP/${split}.x2
+        paste $OUTPATH/QQP/${split}.x1 $OUTPATH/QQP/${split}.x2 > $OUTPATH/QQP/${split}.xlm.tsv
+        rm $OUTPATH/QQP/${split}.x1 $OUTPATH/QQP/${split}.x2
+      fi
+    done
+    rm $OUTPATH/*QQP.zip* 
+
+fi
+
+
+
+# Get BPE codes and vocab
+wget -c https://dl.fbaipublicfiles.com/XLM/codes_xnli_15 -P $MAIN_PATH
+wget -c https://dl.fbaipublicfiles.com/XLM/vocab_xnli_15 -P $MAIN_PATH
+
+# apply BPE codes and binarize the GLUE corpora
+glue_tasks="MNLI QNLI QQP SST-2 STS-B" # TODO: missing MRPC
+
+for task in $glue_tasks
+do
+  if [ ! -d $PROCESSED_PATH/eval/$task ]; then
+    mkdir -p $PROCESSED_PATH/eval/$task
+  else
+    rm -r $PROCESSED_PATH/eval/$task/*
+  fi
+  for splt in train dev test
+  do
+    FPATH=$OUTPATH/${task}/${splt}.xlm.tsv
+
+    cut -f1 $FPATH > ${FPATH}.f1
+    $FASTBPE applybpe $PROCESSED_PATH/eval/$task/${splt}.s1 ${FPATH}.f1 $CODES_PATH
+    python preprocess.py $VOCAB_PATH $PROCESSED_PATH/eval/$task/${splt}.s1
+    rm ${FPATH}.f1
+
+    if [ "$task" != "CoLA" ] && [ "$task" != "SST-2" ]
+    then
+      cut -f2 $FPATH > ${FPATH}.f2
+      $FASTBPE applybpe $PROCESSED_PATH/eval/$task/${splt}.s2 ${FPATH}.f2 $CODES_PATH
+      python preprocess.py $VOCAB_PATH $PROCESSED_PATH/eval/$task/${splt}.s2
+      rm ${FPATH}.f2
+      if [ "$splt" != "test" ] || [ "$task" = "MRPC" ]
+      then
+        cut -f3 $FPATH > $PROCESSED_PATH/eval/$task/${splt}.label
+      fi
+    else
+      if [ "$splt" != "test" ]
+      then
+        cut -f2 $FPATH > $PROCESSED_PATH/eval/$task/${splt}.label
+      fi
+    fi
+  done
+done
+

--- a/get-data-xnli.sh
+++ b/get-data-xnli.sh
@@ -31,13 +31,13 @@ mkdir -p $XNLI_PATH
 # download data
 if [ ! -d $OUTPATH/XNLI-MT-1.0 ]; then
   if [ ! -f $OUTPATH/XNLI-MT-1.0.zip ]; then
-    wget -c https://www.nyu.edu/projects/bowman/xnli/XNLI-MT-1.0.zip -P $OUTPATH
+    wget -c https://dl.fbaipublicfiles.com/XNLI/XNLI-MT-1.0.zip -P $OUTPATH
   fi
   unzip $OUTPATH/XNLI-MT-1.0.zip -d $OUTPATH
 fi
 if [ ! -d $OUTPATH/XNLI-1.0 ]; then
   if [ ! -f $OUTPATH/XNLI-1.0.zip ]; then
-    wget -c https://www.nyu.edu/projects/bowman/xnli/XNLI-1.0.zip -P $OUTPATH
+    wget -c https://dl.fbaipublicfiles.com/XNLI/XNLI-1.0.zip -P $OUTPATH
   fi
   unzip $OUTPATH/XNLI-1.0.zip -d $OUTPATH
 fi

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -44,7 +44,7 @@ fi
 if [ ! -f "$FASTBPE" ]; then
   echo "Compiling fastBPE..."
   cd fastBPE
-  g++ -std=c++11 -pthread -O3 fast.cc -o fast
+  g++ -std=c++11 -pthread -O3 fastBPE/main.cc -IfastBPE -o fast
   cd ..
 fi
 

--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -172,8 +172,13 @@ class Evaluator(object):
                     self.evaluate_clm(scores, data_set, lang1, lang2)
 
                 # prediction task (evaluate perplexity and accuracy)
-
-                self.evaluate_mlm(scores, data_set, 'context', None)
+                if params.model_type == 'transformer':
+                    for lang1, lang2 in params.mlm_steps:
+                        self.evaluate_mlm(scores, data_set, lang1, lang2)
+                elif params.model_type == 'polyencoder':
+                    lang1 = params.mlm_steps[0][0]
+                    lang2 = params.mlm_steps[0][1]
+                    self.evaluate_mlm_poly(scores, data_set, lang1, lang2)
 
                 # machine translation task (evaluate perplexity and accuracy)
                 for lang1, lang2 in set(params.mt_steps + [(l2, l3) for _, l2, l3 in params.bt_steps]):
@@ -233,7 +238,7 @@ class Evaluator(object):
             x, lengths, positions, langs, pred_mask, y = to_cuda(x, lengths, positions, langs, pred_mask, y)
 
             # forward / loss
-            tensor = model('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=True)
+            tensor,_ = model('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=True)
             word_scores, loss = model('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=True)
 
             # update stats
@@ -256,14 +261,64 @@ class Evaluator(object):
         assert lang1 in params.langs
         assert lang2 in params.langs or lang2 is None
 
+        model = self.model if params.encoder_only else self.encoder
+        model.eval()
+        model = model.module if params.multi_gpu else model
 
-        model1 = self.model.encoder_context
-        model1.eval()
-        model1 = model1.module if params.multi_gpu else model1
+        rng = np.random.RandomState(0)
 
-        model2 = self.model.encoder_cand
-        model2.eval()
-        model2 = model2.module if params.multi_gpu else model2
+        lang1_id = params.lang2id[lang1]
+        lang2_id = params.lang2id[lang2] if lang2 is not None else None
+
+        n_words = 0
+        xe_loss = 0
+        n_valid = 0
+
+        for batch in self.get_iterator(data_set, lang1, lang2, stream=(lang2 is None)):
+
+            # batch
+            if lang2 is None:
+                x, lengths = batch
+                positions = None
+                langs = x.clone().fill_(lang1_id) if params.n_langs > 1 else None
+            else:
+                (sent1, len1), (sent2, len2) = batch
+                x, lengths, positions, langs = concat_batches(sent1, len1, lang1_id, sent2, len2, lang2_id, params.pad_index, params.eos_index, reset_positions=True)
+
+            # words to predict
+            x, y, pred_mask = self.mask_out(x, lengths, rng)
+
+            # cuda
+            x, y, pred_mask, lengths, positions, langs = to_cuda(x, y, pred_mask, lengths, positions, langs)
+
+            # forward / loss
+            tensor,_ = model('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
+            word_scores, loss = model('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=True)
+
+            # update stats
+            n_words += len(y)
+            xe_loss += loss.item() * len(y)
+            n_valid += (word_scores.max(1)[1] == y).sum().item()
+
+        # compute perplexity and prediction accuracy
+        ppl_name = '%s_%s_mlm_ppl' % (data_set, lang1) if lang2 is None else '%s_%s-%s_mlm_ppl' % (data_set, lang1, lang2)
+        acc_name = '%s_%s_mlm_acc' % (data_set, lang1) if lang2 is None else '%s_%s-%s_mlm_acc' % (data_set, lang1, lang2)
+        scores[ppl_name] = np.exp(xe_loss / n_words) if n_words > 0 else 1e9
+        scores[acc_name] = 100. * n_valid / n_words if n_words > 0 else 0.
+
+    def evaluate_mlm_poly(self, scores, data_set, lang1, lang2):
+        """
+        Evaluate perplexity and next word prediction accuracy.
+        """
+        params = self.params
+        assert data_set in ['valid', 'test']
+        assert lang1 in params.langs
+        assert lang2 in params.langs or lang2 is None
+
+
+        model = self.model if params.encoder_only else self.encoder
+        model.eval()
+        model = model.module if params.multi_gpu else model
 
         rng = np.random.RandomState(0)
 
@@ -274,52 +329,34 @@ class Evaluator(object):
         xe_loss = 0
         n_valid = 0
 
-        for batch in self.get_iterator(data_set, 'context', lang2, stream=(lang2 is None)):
+        for batch in self.get_iterator(data_set, lang1, None, stream=True):
 
-            # batch
-            if lang2 is None:
-                x, lengths = batch
-                positions = None
-                #langs = x.clone().fill_(lang1_id) if params.n_langs > 1 else None
-            else:
-                (sent1, len1), (sent2, len2) = batch
-                x, lengths, positions, langs = concat_batches(sent1, len1, lang1_id, sent2, len2, lang2_id, params.pad_index, params.eos_index, reset_positions=True)
-
-            # words to predict
+            # batch, word to predict, cuda
+            x, lengths = batch
+            positions = None
             x, y, pred_mask = self.mask_out(x, lengths, rng)
-
-            # cuda
             x, y, pred_mask, lengths, positions = to_cuda(x, y, pred_mask, lengths, positions)
 
             # forward / loss
-            tensor = model1('fwd', x=x, lengths=lengths, positions=positions, langs=None, causal=False)
-            word_scores, loss = model1('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=True)
+            tensor,_ = model.encoder_context('fwd', x=x, lengths=lengths, positions=positions, langs=None, causal=False)
+            word_scores, loss = model.encoder_context('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=True)
 
             # update stats
             n_words += len(y)
             xe_loss += loss.item() * len(y)
             n_valid += (word_scores.max(1)[1] == y).sum().item()
 
-        for batch in self.get_iterator(data_set, 'cand', lang2, stream=(lang2 is None)):
+        for batch in self.get_iterator(data_set, lang2, None, stream=True):
 
-            # batch
-            if lang2 is None:
-                x, lengths = batch
-                positions = None
-                #langs = x.clone().fill_(lang1_id) if params.n_langs > 1 else None
-            else:
-                (sent1, len1), (sent2, len2) = batch
-                x, lengths, positions, langs = concat_batches(sent1, len1, lang1_id, sent2, len2, lang2_id, params.pad_index, params.eos_index, reset_positions=True)
-
-            # words to predict
+            #batch, word to predict, cuda
+            x, lengths = batch
+            positions = None
             x, y, pred_mask = self.mask_out(x, lengths, rng)
-
-            # cuda
             x, y, pred_mask, lengths, positions = to_cuda(x, y, pred_mask, lengths, positions)
 
             # forward / loss
-            tensor = model2('fwd', x=x, lengths=lengths, positions=positions, langs=None, causal=False)
-            word_scores, loss = model2('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=True)
+            tensor,_ = model.encoder_cand('fwd', x=x, lengths=lengths, positions=positions, langs=None, causal=False)
+            word_scores, loss = model.encoder_cand('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=True)
 
             # update stats
             n_words += len(y)
@@ -327,8 +364,8 @@ class Evaluator(object):
             n_valid += (word_scores.max(1)[1] == y).sum().item()
 
         # compute perplexity and prediction accuracy
-        ppl_name = '%s_%s_mlm_ppl' % (data_set, 'context-cand') if lang2 is None else '%s_%s-%s_mlm_ppl' % (data_set, lang1, lang2)
-        acc_name = '%s_%s_mlm_acc' % (data_set, 'context-cand') if lang2 is None else '%s_%s-%s_mlm_acc' % (data_set, lang1, lang2)
+        ppl_name = '%s_%s-%s_mlm_ppl' % (data_set, lang1, lang2)
+        acc_name = '%s_%s-%s_mlm_acc' % (data_set, lang1, lang2)
         scores[ppl_name] = np.exp(xe_loss / n_words) if n_words > 0 else 1e9
         scores[acc_name] = 100. * n_valid / n_words if n_words > 0 else 0.
 
@@ -397,7 +434,7 @@ class EncDecEvaluator(Evaluator):
             x1, len1, langs1, x2, len2, langs2, y = to_cuda(x1, len1, langs1, x2, len2, langs2, y)
 
             # encode source sentence
-            enc1 = encoder('fwd', x=x1, lengths=len1, langs=langs1, causal=False)
+            enc1,_ = encoder('fwd', x=x1, lengths=len1, langs=langs1, causal=False)
             enc1 = enc1.transpose(0, 1)
 
             # decode target sentence

--- a/src/evaluation/glue.py
+++ b/src/evaluation/glue.py
@@ -285,7 +285,7 @@ class GLUE:
                     lines = [l.rstrip() for l in f]
                 # STS-B task
                 if task == 'STS-B':
-                    assert all(x in ['0', '1'] for x in lines)
+                    assert all(0 <= float(x) <= 5 for x in lines)
                     y = [float(l) for l in lines]
                 # QQP
                 elif task == 'QQP':

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -10,7 +10,7 @@ import os
 import torch
 
 from .pretrain import load_embeddings
-from .transformer import DECODER_ONLY_PARAMS, TransformerModel  # , TRANSFORMER_LAYER_PARAMS
+from .transformer import DECODER_ONLY_PARAMS, TransformerModel, PolyEncoder  # , TRANSFORMER_LAYER_PARAMS
 
 
 logger = getLogger()
@@ -93,7 +93,13 @@ def build_model(params, dico):
     """
     if params.encoder_only:
         # build
-        model = TransformerModel(params, dico, is_encoder=True, with_output=True)
+        assert params.model_type in ['transformer','polyencoder']
+
+        if params.model_type == 'polyencoder':
+            model = PolyEncoder(params, dico, is_encoder=True, with_output=True)
+        elif params.model_type == 'transformer':
+            model = TransformerModel(params, dico, is_encoder=True, with_output=True)
+
 
         # reload pretrained word embeddings
         if params.reload_emb != '':

--- a/src/model/transformer.py
+++ b/src/model/transformer.py
@@ -12,9 +12,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import pdb
 
 
-N_MAX_POSITIONS = 512  # maximum input sequence length
+N_MAX_POSITIONS = 1024  # maximum input sequence length
 
 DECODER_ONLY_PARAMS = [
     'layer_norm15.%i.weight', 'layer_norm15.%i.bias',
@@ -273,8 +274,8 @@ class TransformerModel(nn.Module):
         self.position_embeddings = Embedding(N_MAX_POSITIONS, self.dim)
         if params.sinusoidal_embeddings:
             create_sinusoidal_embeddings(N_MAX_POSITIONS, self.dim, out=self.position_embeddings.weight)
-        if params.n_langs > 1:
-            self.lang_embeddings = Embedding(self.n_langs, self.dim)
+        #if params.n_langs > 1:
+            #self.lang_embeddings = Embedding(self.n_langs, self.dim)
         self.embeddings = Embedding(self.n_words, self.dim, padding_idx=self.pad_index)
         self.layer_norm_emb = nn.LayerNorm(self.dim, eps=1e-12)
 
@@ -367,8 +368,8 @@ class TransformerModel(nn.Module):
         # embeddings
         tensor = self.embeddings(x)
         tensor = tensor + self.position_embeddings(positions).expand_as(tensor)
-        if langs is not None:
-            tensor = tensor + self.lang_embeddings(langs)
+        #if langs is not None:
+        #    tensor = tensor + self.lang_embeddings(langs)
         tensor = self.layer_norm_emb(tensor)
         tensor = F.dropout(tensor, p=self.dropout, training=self.training)
         tensor *= mask.unsqueeze(-1).to(tensor.dtype)
@@ -401,7 +402,7 @@ class TransformerModel(nn.Module):
         # move back sequence length to dimension 0
         tensor = tensor.transpose(0, 1)
 
-        return tensor
+        return tensor, mask
 
     def predict(self, tensor, pred_mask, y, get_scores):
         """
@@ -722,3 +723,48 @@ class BeamHypotheses(object):
             return True
         else:
             return self.worst_score >= best_sum_logprobs / self.max_len ** self.length_penalty
+
+class PolyEncoder(nn.Module):
+
+    def __init__(self, params, dico, is_encoder, with_output):
+        super().__init__()
+        self.encoder_context = TransformerModel(params, dico, is_encoder, with_output)
+        self.encoder_cand = TransformerModel(params, dico, is_encoder, with_output)
+
+        codes = torch.ones(16,params.emb_dim)
+        self.codes = torch.nn.Parameter(codes)
+
+    def basic_attention(self, xs, ys, mask_ys=None, dim=2):
+
+        pdb.set_trace()
+        bsz = xs.size(0)
+        y_len = ys.size(1)
+        dtype = xs.dtype
+        num_attention = xs.size(1)
+        l1 = torch.bmm(xs, ys.transpose(1, 2))
+        if mask_ys is not None:
+            attn_mask = (mask_ys == 0).view(bsz, 1, y_len)
+            attn_mask = attn_mask.repeat(1,num_attention,1)
+            # assert attn_mask.shape == l1.shape
+            l1.masked_fill_(attn_mask, -65504)
+
+        weight = F.softmax(l1, dim=dim)
+
+        emb = torch.bmm(weight, ys)
+        return emb, weight
+
+
+
+    def forward(self, x1, len1, x2, len2 ):
+
+        h1, mask = self.encoder_context('fwd', x=x1, lengths=len1, causal=False)
+        h1 = h1.transpose(0,1) # bs x seq_len x 768
+        h2, _ = self.encoder_cand('fwd', x=x2, lengths=len2, causal=False)
+        h2 = h2[0]
+        bs = h1.size(0)
+        cands = h2.repeat(bs,1,1)
+        attention_vecs, _ = self.basic_attention(self.codes.repeat(bs,1,1), h1, mask)  #bs x num_cdes x 768
+        pdb.set_trace()
+        context_cand_emb, _ = self.basic_attention(cands, attention_vecs) #bs x cands x 768
+
+        return context_cand_emb, h2

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -444,13 +444,18 @@ class Trainer(object):
         """
         checkpoint_path = os.path.join(self.params.dump_path, 'checkpoint.pth')
         if not os.path.isfile(checkpoint_path):
-            return
+            if self.params.reload_checkpoint == '':
+                return
+            else:
+                checkpoint_path = self.params.reload_checkpoint
+                assert os.path.isfile(checkpoint_path)
         logger.warning('Reloading checkpoint from %s ...' % checkpoint_path)
         data = torch.load(checkpoint_path, map_location=lambda storage, loc: storage.cuda(self.params.local_rank))
 
         # reload model parameters and optimizers
         for name in self.MODEL_NAMES:
             getattr(self, name).load_state_dict(data[name])
+            # getattr(self, name).load_state_dict({k[len('module.'):]: v for k, v in data[name].items()})
             self.optimizers[name].load_state_dict(data[name + '_optimizer'])
 
         # reload main metrics

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 #
-
 import os
 import math
 import time
@@ -15,7 +14,6 @@ import torch
 from torch.nn import functional as F
 from torch.nn.utils import clip_grad_norm_
 from apex.fp16_utils import FP16_Optimizer
-
 from .utils import get_optimizer, to_cuda, concat_batches
 from .utils import parse_lambda_config, update_lambdas
 
@@ -91,6 +89,7 @@ class Trainer(object):
         self.last_time = time.time()
 
         # reload potential checkpoints
+        #self.reload_checkpoint()
         self.reload_checkpoint()
 
         # initialize lambda coefficients and their configurations
@@ -438,6 +437,7 @@ class Trainer(object):
         logger.info("Saving checkpoint to %s ..." % checkpoint_path)
         torch.save(data, checkpoint_path)
 
+
     def reload_checkpoint(self):
         """
         Reload a checkpoint if we find one.
@@ -551,6 +551,59 @@ class Trainer(object):
         assert x.size(1) % 8 == 0
         return x, lengths, positions, langs, idx
 
+    def round_second_batch(self, x, lengths, positions, langs, idx):
+        """
+        For float16 only.
+        Sub-sample sentences in a batch, and add padding,
+        so that each dimension is a multiple of 8.
+        """
+        params = self.params
+        if not params.fp16 or len(lengths) < 8:
+            return x, lengths, positions, langs
+
+        bs1 = len(lengths)
+        bs2 = 8 * (bs1 // 8)
+        assert bs2 > 0 and bs2 % 8 == 0
+
+        if idx is not None:
+            lengths = lengths[idx]
+            slen = lengths.max().item()
+            x = x[:slen, idx]
+            positions = None if positions is None else positions[:slen, idx]
+            langs = None if langs is None else langs[:slen, idx]
+
+        # sequence length == 0 [8]
+        ml1 = x.size(0)
+        if ml1 % 8 != 0:
+            pad = 8 - (ml1 % 8)
+            ml2 = ml1 + pad
+            x = torch.cat([x, torch.LongTensor(pad, bs2).fill_(params.pad_index)], 0)
+            if positions is not None:
+                positions = torch.cat([positions, torch.arange(pad)[:, None] + positions[-1][None] + 1], 0)
+            if langs is not None:
+                langs = torch.cat([langs, langs[-1][None].expand(pad, bs2)], 0)
+            assert x.size() == (ml2, bs2)
+
+        assert x.size(0) % 8 == 0
+        assert x.size(1) % 8 == 0
+        return x, lengths, positions, langs
+
+
+    def loss_poly(self, context_cand, cand):
+        bs = context_cand.size(0)
+        dim = context_cand.size(2)
+
+        context_cand = context_cand.reshape(bs*bs,-1)
+        cand = cand.repeat(bs,1)
+        scores = torch.bmm(context_cand.reshape(bs*bs,1,dim), cand.reshape(bs*bs,dim,1)).reshape(bs,bs)
+
+        targets = scores.new_empty(bs).long()
+        targets = torch.arange(bs, out=targets)
+
+        loss = F.cross_entropy(scores, targets.to(scores.device))
+        return loss
+
+
     def clm_step(self, lang1, lang2, lambda_coeff):
         """
         Next word prediction step (causal prediction).
@@ -600,26 +653,38 @@ class Trainer(object):
         if lambda_coeff == 0:
             return
         params = self.params
-        name = 'model' if params.encoder_only else 'encoder'
-        model = getattr(self, name)
-        model.train()
+        self.model.train()
+
 
         # generate batch / select words to predict
-        x, lengths, positions, langs, _ = self.generate_batch(lang1, lang2, 'pred')
-        x, lengths, positions, langs, _ = self.round_batch(x, lengths, positions, langs)
+        x, lengths, positions, langs, _ = self.generate_batch('context', lang2, 'pred')
+        #x, lengths, positions, langs, _ = self.round_batch(x, lengths, positions, langs)
         x, y, pred_mask = self.mask_out(x, lengths)
 
         # cuda
         x, y, pred_mask, lengths, positions, langs = to_cuda(x, y, pred_mask, lengths, positions, langs)
-
         # forward / loss
-        tensor = model('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
-        _, loss = model('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
-        self.stats[('MLM-%s' % lang1) if lang2 is None else ('MLM-%s-%s' % (lang1, lang2))].append(loss.item())
-        loss = lambda_coeff * loss
+        tensor, _ = self.model.encoder_context('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
+        _, loss_context = self.model.encoder_context('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
+        self.stats[('MLM-%s' % 'context') if lang2 is None else ('MLM-%s-%s' % (lang1, lang2))].append(loss_context.item())
 
+        # generate batch / select words to predict
+        x, lengths, positions, langs, _ = self.generate_batch('cand', lang2, 'pred')
+        #x, lengths, positions, langs, _ = self.round_batch(x, lengths, positions, langs)
+        x, y, pred_mask = self.mask_out(x, lengths)
+
+        # cuda
+        x, y, pred_mask, lengths, positions, langs = to_cuda(x, y, pred_mask, lengths, positions, langs)
+        # forward / loss
+        tensor,_ = self.model.encoder_cand('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
+        _, loss_cand = self.model.encoder_cand('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
+        self.stats[('MLM-%s' % 'cand') if lang2 is None else ('MLM-%s-%s' % (lang1, lang2))].append(loss_cand.item())
+
+        s = sum([param.sum() for param in self.model.parameters()]) * 0
+
+        loss = lambda_coeff * (loss_context + loss_cand + s)
         # optimize
-        self.optimize(loss, name)
+        self.optimize(loss, 'model')
 
         # number of processed sentences / words
         self.n_sentences += params.batch_size
@@ -634,9 +699,7 @@ class Trainer(object):
         if lambda_coeff == 0:
             return
         params = self.params
-        name = 'model' if params.encoder_only else 'encoder'
-        model = getattr(self, name)
-        model.train()
+        self.model.train()
 
         lang1_id = params.lang2id[lang1]
         lang2_id = params.lang2id[lang2]
@@ -648,38 +711,35 @@ class Trainer(object):
             self.n_sentences += params.batch_size
             return
 
-        # associate lang1 sentences with their translations, and random lang2 sentences
-        y = torch.LongTensor(bs).random_(2)
-        idx_pos = torch.arange(bs)
-        idx_neg = ((idx_pos + torch.LongTensor(bs).random_(1, bs)) % bs)
-        idx = (y == 1).long() * idx_pos + (y == 0).long() * idx_neg
-        x2, len2 = x2[:, idx], len2[idx]
 
-        # generate batch / cuda
-        x, lengths, positions, langs = concat_batches(x1, len1, lang1_id, x2, len2, lang2_id, params.pad_index, params.eos_index, reset_positions=False)
-        x, lengths, positions, langs, new_idx = self.round_batch(x, lengths, positions, langs)
-        if new_idx is not None:
-            y = y[new_idx]
-        x, lengths, positions, langs = to_cuda(x, lengths, positions, langs)
+        x1, len1, _, _, idx = self.round_batch(x1, len1, None, None)
+        x2, len2, _, _ = self.round_second_batch(x2, len2, None, None, idx)
+
+        x1, len1 = to_cuda(x1, len1)
+        x2, len2 = to_cuda(x2, len2)
+
 
         # get sentence embeddings
-        h = model('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)[0]
+        context_cand_emb, cand = self.model(x1, len1, x2, len2)
 
-        # parallel classification loss
-        CLF_ID1, CLF_ID2 = 8, 9  # very hacky, use embeddings to make weights for the classifier
-        emb = (model.module if params.multi_gpu else model).embeddings.weight
-        pred = F.linear(h, emb[CLF_ID1].unsqueeze(0), emb[CLF_ID2, 0])
-        loss = F.binary_cross_entropy_with_logits(pred.view(-1), y.to(pred.device).type_as(pred))
+
+
+        # next sentence loss
+        loss = self.loss_poly(context_cand_emb,cand)
+
+        s = sum([param.sum() for param in self.model.parameters()]) * 0
+
+
         self.stats['PC-%s-%s' % (lang1, lang2)].append(loss.item())
-        loss = lambda_coeff * loss
+        loss = lambda_coeff * loss + s
 
         # optimize
-        self.optimize(loss, name)
+        self.optimize(loss, ['model'])
 
         # number of processed sentences / words
         self.n_sentences += params.batch_size
         self.stats['processed_s'] += bs
-        self.stats['processed_w'] += lengths.sum().item()
+        self.stats['processed_w'] += 2 * len1.sum().item()
 
 
 class SingleTrainer(Trainer):
@@ -688,13 +748,13 @@ class SingleTrainer(Trainer):
 
         self.MODEL_NAMES = ['model']
 
-        # model / data / params
         self.model = model
         self.data = data
         self.params = params
 
         # optimizers
         self.optimizers = {'model': self.get_optimizer_fp('model')}
+
 
         super().__init__(data, params)
 

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -590,6 +590,8 @@ class Trainer(object):
 
 
     def loss_poly(self, context_cand, cand):
+        #context_cand is bs x bs x emb_dim
+        #cand is bs x emb_dim
         bs = context_cand.size(0)
         dim = context_cand.size(2)
 
@@ -631,7 +633,7 @@ class Trainer(object):
         x, lengths, langs, pred_mask, y = to_cuda(x, lengths, langs, pred_mask, y)
 
         # forward / loss
-        tensor = model('fwd', x=x, lengths=lengths, langs=langs, causal=True)
+        tensor, _ = model('fwd', x=x, lengths=lengths, langs=langs, causal=True)
         _, loss = model('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
         self.stats[('CLM-%s' % lang1) if lang2 is None else ('CLM-%s-%s' % (lang1, lang2))].append(loss.item())
         loss = lambda_coeff * loss
@@ -653,36 +655,59 @@ class Trainer(object):
         if lambda_coeff == 0:
             return
         params = self.params
-        self.model.train()
+        name = 'model' if params.encoder_only else 'encoder'
+        model = getattr(self, name)
+        model.train()
 
 
-        # generate batch / select words to predict
-        x, lengths, positions, langs, _ = self.generate_batch('context', lang2, 'pred')
-        #x, lengths, positions, langs, _ = self.round_batch(x, lengths, positions, langs)
-        x, y, pred_mask = self.mask_out(x, lengths)
+        if params.model_type == "transformer":
+                # generate batch / select words to predict
+                x, lengths, positions, langs, _ = self.generate_batch(lang1, lang2, 'pred')
+                x, lengths, positions, langs, _ = self.round_batch(x, lengths, positions, langs)
+                x, y, pred_mask = self.mask_out(x, lengths)
 
-        # cuda
-        x, y, pred_mask, lengths, positions, langs = to_cuda(x, y, pred_mask, lengths, positions, langs)
-        # forward / loss
-        tensor, _ = self.model.encoder_context('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
-        _, loss_context = self.model.encoder_context('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
-        self.stats[('MLM-%s' % 'context') if lang2 is None else ('MLM-%s-%s' % (lang1, lang2))].append(loss_context.item())
+                # cuda
+                x, y, pred_mask, lengths, positions, langs = to_cuda(x, y, pred_mask, lengths, positions, langs)
 
-        # generate batch / select words to predict
-        x, lengths, positions, langs, _ = self.generate_batch('cand', lang2, 'pred')
-        #x, lengths, positions, langs, _ = self.round_batch(x, lengths, positions, langs)
-        x, y, pred_mask = self.mask_out(x, lengths)
+                # forward / loss
+                tensor, _ = model('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
+                _, loss = model('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
+                self.stats[('MLM-%s' % lang1) if lang2 is None else ('MLM-%s-%s' % (lang1, lang2))].append(loss.item())
+                loss = lambda_coeff * loss
 
-        # cuda
-        x, y, pred_mask, lengths, positions, langs = to_cuda(x, y, pred_mask, lengths, positions, langs)
-        # forward / loss
-        tensor,_ = self.model.encoder_cand('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
-        _, loss_cand = self.model.encoder_cand('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
-        self.stats[('MLM-%s' % 'cand') if lang2 is None else ('MLM-%s-%s' % (lang1, lang2))].append(loss_cand.item())
+        if params.model_type == "polyencoder":
 
-        s = sum([param.sum() for param in self.model.parameters()]) * 0
+            assert len(params.mlm_steps) == 2
+            for langs in params.mlm_steps:
+                assert langs[1] is None
 
-        loss = lambda_coeff * (loss_context + loss_cand + s)
+            # MLM on the context_encoder with the context data
+            lang_context =   params.mlm_steps[0][0]
+            # generate batch / select words to predict
+            x, lengths, positions, _, _ = self.generate_batch(lang_context, None, 'pred')
+            x, y, pred_mask = self.mask_out(x, lengths)
+            x, y, pred_mask, lengths, positions = to_cuda(x, y, pred_mask, lengths, positions)
+            # forward / loss
+            tensor, _ = self.model.encoder_context('fwd', x=x, lengths=lengths, positions=positions, langs=None, causal=False)
+            _, loss_context = self.model.encoder_context('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
+            self.stats[('MLM-%s' % lang_context)].append(loss_context.item())
+
+            # MLM on the cand_encoder with the candidate data
+            lang_cand =   params.mlm_steps[1][0]
+            # generate batch / select words to predict
+            x, lengths, positions, _, _ = self.generate_batch(lang_cand, None, 'pred')
+            x, y, pred_mask = self.mask_out(x, lengths)
+            x, y, pred_mask, lengths, positions = to_cuda(x, y, pred_mask, lengths, positions)
+            # forward / loss
+            tensor,_ = self.model.encoder_cand('fwd', x=x, lengths=lengths, positions=positions, langs=None, causal=False)
+            _, loss_cand = self.model.encoder_cand('predict', tensor=tensor, pred_mask=pred_mask, y=y, get_scores=False)
+            self.stats[('MLM-%s' % lang_cand)].append(loss_cand.item())
+
+            # have to add the parameters not used (codes of the poly-encoder) to make it work on multi-machine
+            s = sum([param.sum() for param in self.model.parameters()]) * 0
+            loss = loss_context + loss_cand + s
+
+        loss = lambda_coeff * loss
         # optimize
         self.optimize(loss, 'model')
 
@@ -699,7 +724,9 @@ class Trainer(object):
         if lambda_coeff == 0:
             return
         params = self.params
-        self.model.train()
+        name = 'model' if params.encoder_only else 'encoder'
+        model = getattr(self, name)
+        model.train()
 
         lang1_id = params.lang2id[lang1]
         lang2_id = params.lang2id[lang2]
@@ -712,26 +739,54 @@ class Trainer(object):
             return
 
 
-        x1, len1, _, _, idx = self.round_batch(x1, len1, None, None)
-        x2, len2, _, _ = self.round_second_batch(x2, len2, None, None, idx)
+        if params.model_type == 'transformer':
 
-        x1, len1 = to_cuda(x1, len1)
-        x2, len2 = to_cuda(x2, len2)
+            # associate lang1 sentences with their translations, and random lang2 sentences
+            y = torch.LongTensor(bs).random_(2)
+            idx_pos = torch.arange(bs)
+            idx_neg = ((idx_pos + torch.LongTensor(bs).random_(1, bs)) % bs)
+            idx = (y == 1).long() * idx_pos + (y == 0).long() * idx_neg
+            x2, len2 = x2[:, idx], len2[idx]
+
+            # generate batch / cuda
+            x, lengths, positions, langs = concat_batches(x1, len1, lang1_id, x2, len2, lang2_id, params.pad_index, params.eos_index, reset_positions=False)
+            x, lengths, positions, langs, new_idx = self.round_batch(x, lengths, positions, langs)
+            if new_idx is not None:
+                y = y[new_idx]
+            x, lengths, positions, langs = to_cuda(x, lengths, positions, langs)
+
+            # get sentence embeddings
+            h, _ = model('fwd', x=x, lengths=lengths, positions=positions, langs=langs, causal=False)
+            h = h[0]
+
+            # parallel classification loss
+            CLF_ID1, CLF_ID2 = 8, 9  # very hacky, use embeddings to make weights for the classifier
+            emb = (model.module if params.multi_gpu else model).embeddings.weight
+            pred = F.linear(h, emb[CLF_ID1].unsqueeze(0), emb[CLF_ID2, 0])
+            loss = F.binary_cross_entropy_with_logits(pred.view(-1), y.to(pred.device).type_as(pred))
+
+        if params.model_type == 'polyencoder':
+
+            x1, len1, _, _, idx = self.round_batch(x1, len1, None, None)
+            x2, len2, _, _ = self.round_second_batch(x2, len2, None, None, idx)
+
+            x1, len1 = to_cuda(x1, len1)
+            x2, len2 = to_cuda(x2, len2)
 
 
-        # get sentence embeddings
-        context_cand_emb, cand = self.model(x1, len1, x2, len2)
+            # get sentence embeddings
+            #context_cand_emb is bs x bs x emb_dim
+            # cand is bs x emb_dim
+            context_cand_emb, cand = self.model(x1, len1, x2, len2)
 
-
-
-        # next sentence loss
-        loss = self.loss_poly(context_cand_emb,cand)
-
-        s = sum([param.sum() for param in self.model.parameters()]) * 0
+            # next sentence loss
+            loss = self.loss_poly(context_cand_emb,cand)
+            s = sum([param.sum() for param in self.model.parameters()]) * 0
+            loss = s + loss
 
 
         self.stats['PC-%s-%s' % (lang1, lang2)].append(loss.item())
-        loss = lambda_coeff * loss + s
+        loss = lambda_coeff * loss
 
         # optimize
         self.optimize(loss, ['model'])

--- a/train.py
+++ b/train.py
@@ -163,11 +163,13 @@ def get_parser():
     parser.add_argument("--pc_steps", type=str, default="",
                         help="Parallel classification steps")
 
-    # reload a pretrained model
+    # reload pretrained embeddings / pretrained model / checkpoint
     parser.add_argument("--reload_emb", type=str, default="",
                         help="Reload pretrained word embeddings")
     parser.add_argument("--reload_model", type=str, default="",
                         help="Reload a pretrained model")
+    parser.add_argument("--reload_checkpoint", type=str, default="",
+                        help="Reload a checkpoint")
 
     # beam search (for MT only)
     parser.add_argument("--beam_size", type=int, default=1,

--- a/train.py
+++ b/train.py
@@ -124,6 +124,8 @@ def get_parser():
                         help="Split data across workers of a same node")
     parser.add_argument("--optimizer", type=str, default="adam,lr=0.0001",
                         help="Optimizer (SGD / RMSprop / Adam, etc.)")
+    parser.add_argument("--clip_grad_norm", type=float, default=5,
+                        help="Clip gradients norm (0 to disable)")
     parser.add_argument("--epoch_size", type=int, default=100000,
                         help="Epoch size / evaluation frequency (-1 for parallel data size)")
     parser.add_argument("--max_epoch", type=int, default=100000,

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ import json
 import argparse
 import torch
 from torch import nn
+import pdb
 
 from src.slurm import init_signal_handler, init_distributed_mode
 from src.data.loader import check_data_params, load_data
@@ -196,6 +197,8 @@ def get_parser():
                         help="Multi-GPU - Local rank")
     parser.add_argument("--master_port", type=int, default=-1,
                         help="Master port (for multi-node SLURM jobs)")
+    parser.add_argument("--model_type", type=str, default="transformer",
+                        help="Type of model that is trained. 'transformer' or 'polyencoder'")
 
     return parser
 
@@ -216,6 +219,7 @@ def main(params):
 
     # build model
     if params.encoder_only:
+        pdb.set_trace()
         model = build_model(params, data['dico'])
     else:
         encoder, decoder = build_model(params, data['dico'])

--- a/train.py
+++ b/train.py
@@ -301,6 +301,7 @@ def main(params):
 
         # evaluate perplexity
         scores = evaluator.run_all_evals(trainer)
+        print
 
         # print / JSON log
         for k, v in scores.items():

--- a/train.py
+++ b/train.py
@@ -9,7 +9,6 @@ import json
 import argparse
 import torch
 from torch import nn
-import pdb
 
 from src.slurm import init_signal_handler, init_distributed_mode
 from src.data.loader import check_data_params, load_data
@@ -217,7 +216,6 @@ def main(params):
 
     # build model
     if params.encoder_only:
-        pdb.set_trace()
         model = build_model(params, data['dico'])
     else:
         encoder, decoder = build_model(params, data['dico'])

--- a/train.py
+++ b/train.py
@@ -9,7 +9,6 @@ import json
 import argparse
 import torch
 from torch import nn
-import pdb
 
 from src.slurm import init_signal_handler, init_distributed_mode
 from src.data.loader import check_data_params, load_data
@@ -219,7 +218,6 @@ def main(params):
 
     # build model
     if params.encoder_only:
-        pdb.set_trace()
         model = build_model(params, data['dico'])
     else:
         encoder, decoder = build_model(params, data['dico'])

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ import json
 import argparse
 import torch
 from torch import nn
+import pdb
 
 from src.slurm import init_signal_handler, init_distributed_mode
 from src.data.loader import check_data_params, load_data
@@ -194,6 +195,8 @@ def get_parser():
                         help="Multi-GPU - Local rank")
     parser.add_argument("--master_port", type=int, default=-1,
                         help="Master port (for multi-node SLURM jobs)")
+    parser.add_argument("--model_type", type=str, default="transformer",
+                        help="Type of model that is trained. 'transformer' or 'polyencoder'")
 
     return parser
 
@@ -214,6 +217,7 @@ def main(params):
 
     # build model
     if params.encoder_only:
+        pdb.set_trace()
         model = build_model(params, data['dico'])
     else:
         encoder, decoder = build_model(params, data['dico'])

--- a/train.py
+++ b/train.py
@@ -303,6 +303,7 @@ def main(params):
 
         # evaluate perplexity
         scores = evaluator.run_all_evals(trainer)
+        print
 
         # print / JSON log
         for k, v in scores.items():

--- a/translate.py
+++ b/translate.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Translate sentences from the input stream.
+# The model will be faster is sentences are sorted by length.
+# Input sentences must have the same tokenization and BPE codes than the ones used in the model.
+#
+# Usage:
+#     cat source_sentences.bpe | \
+#     python translate.py --exp_name translate \
+#     --src_lang en --tgt_lang fr \
+#     --model_path trained_model.pth --output_path output
+#
+
+import os
+import io
+import sys
+import argparse
+import torch
+
+from src.utils import AttrDict
+from src.utils import bool_flag, initialize_exp
+from src.data.dictionary import Dictionary
+from src.model.transformer import TransformerModel
+
+from src.fp16 import network_to_half
+
+
+def get_parser():
+    """
+    Generate a parameters parser.
+    """
+    # parse parameters
+    parser = argparse.ArgumentParser(description="Translate sentences")
+
+    # main parameters
+    parser.add_argument("--dump_path", type=str, default="./dumped/", help="Experiment dump path")
+    parser.add_argument("--exp_name", type=str, default="", help="Experiment name")
+    parser.add_argument("--exp_id", type=str, default="", help="Experiment ID")
+    parser.add_argument("--fp16", type=bool_flag, default=False, help="Run model with float16")
+    parser.add_argument("--batch_size", type=int, default=32, help="Number of sentences per batch")
+
+    # model / output paths
+    parser.add_argument("--model_path", type=str, default="", help="Model path")
+    parser.add_argument("--output_path", type=str, default="", help="Output path")
+
+    # parser.add_argument("--max_vocab", type=int, default=-1, help="Maximum vocabulary size (-1 to disable)")
+    # parser.add_argument("--min_count", type=int, default=0, help="Minimum vocabulary count")
+
+    # source language / target language
+    parser.add_argument("--src_lang", type=str, default="", help="Source language")
+    parser.add_argument("--tgt_lang", type=str, default="", help="Target language")
+
+    return parser
+
+
+def main(params):
+
+    # initialize the experiment
+    logger = initialize_exp(params)
+
+    # generate parser / parse parameters
+    parser = get_parser()
+    params = parser.parse_args()
+    reloaded = torch.load(params.model_path)
+    model_params = AttrDict(reloaded['params'])
+    logger.info("Supported languages: %s" % ", ".join(model_params.lang2id.keys()))
+
+    # update dictionary parameters
+    for name in ['n_words', 'bos_index', 'eos_index', 'pad_index', 'unk_index', 'mask_index']:
+        setattr(params, name, getattr(model_params, name))
+
+    # build dictionary / build encoder / build decoder / reload weights
+    dico = Dictionary(reloaded['dico_id2word'], reloaded['dico_word2id'], reloaded['dico_counts'])
+    encoder = TransformerModel(model_params, dico, is_encoder=True, with_output=True).cuda().eval()
+    decoder = TransformerModel(model_params, dico, is_encoder=False, with_output=True).cuda().eval()
+    encoder.load_state_dict(reloaded['encoder'])
+    decoder.load_state_dict(reloaded['decoder'])
+    params.src_id = model_params.lang2id[params.src_lang]
+    params.tgt_id = model_params.lang2id[params.tgt_lang]
+
+    # float16
+    if params.fp16:
+        assert torch.backends.cudnn.enabled
+        encoder = network_to_half(encoder)
+        decoder = network_to_half(decoder)
+
+    # read sentences from stdin
+    src_sent = []
+    for line in sys.stdin.readlines():
+        assert len(line.strip().split()) > 0
+        src_sent.append(line)
+    logger.info("Read %i sentences from stdin. Translating ..." % len(src_sent))
+
+    f = io.open(params.output_path, 'w', encoding='utf-8')
+
+    for i in range(0, len(src_sent), params.batch_size):
+
+        # prepare batch
+        word_ids = [torch.LongTensor([dico.index(w) for w in s.strip().split()])
+                    for s in src_sent[i:i + params.batch_size]]
+        lengths = torch.LongTensor([len(s) + 2 for s in word_ids])
+        batch = torch.LongTensor(lengths.max().item(), lengths.size(0)).fill_(params.pad_index)
+        batch[0] = params.eos_index
+        for j, s in enumerate(word_ids):
+            if lengths[j] > 2:  # if sentence not empty
+                batch[1:lengths[j] - 1, j].copy_(s)
+            batch[lengths[j] - 1, j] = params.eos_index
+        langs = batch.clone().fill_(params.src_id)
+
+        # encode source batch and translate it
+        encoded = encoder('fwd', x=batch.cuda(), lengths=lengths.cuda(), langs=langs.cuda(), causal=False)
+        encoded = encoded.transpose(0, 1)
+        decoded, dec_lengths = decoder.generate(encoded, lengths.cuda(), params.tgt_id, max_len=int(1.5 * lengths.max().item() + 10))
+
+        # convert sentences to words
+        for j in range(decoded.size(1)):
+
+            # remove delimiters
+            sent = decoded[:, j]
+            delimiters = (sent == params.eos_index).nonzero().view(-1)
+            assert len(delimiters) >= 1 and delimiters[0].item() == 0
+            sent = sent[1:] if len(delimiters) == 1 else sent[1:delimiters[1]]
+
+            # output translation
+            source = src_sent[i + j].strip()
+            target = " ".join([dico[sent[k].item()] for k in range(len(sent))])
+            sys.stderr.write("%i / %i: %s -> %s\n" % (i + j, len(src_sent), source, target))
+            f.write(target + "\n")
+
+    f.close()
+
+
+if __name__ == '__main__':
+
+    # generate parser / parse parameters
+    parser = get_parser()
+    params = parser.parse_args()
+
+    # check parameters
+    assert os.path.isfile(params.model_path)
+    assert params.src_lang != '' and params.tgt_lang != '' and params.src_lang != params.tgt_lang
+    assert params.output_path and not os.path.isfile(params.output_path)
+
+    # translate
+    with torch.no_grad():
+        main(params)


### PR DESCRIPTION
Add the poly encoder class.
Change code to make mlm_step, mlm_evaluator, pc_step working for the poly-encoder.
To train a poly-encoder instead of a single transformer, argument 'model_type' = polyencoder
The code is compatible with the original version of XLM, ie when model_type is set to default value 'transformer'.

Test the code locally with 'model_type' = 'transformer' and 'model_type'='poly_encoder' and it seems to works properly.  I have a pb launching the code in multi-gpu locally though, so I can test if it works in multigpu locally. It probably needs a ".module" somewhere. I need to check that